### PR TITLE
run bower install before running bundle

### DIFF
--- a/src/AssetManager.Web/AssetManager.Web.csproj
+++ b/src/AssetManager.Web/AssetManager.Web.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\AssetManager.Infrastructure\AssetManager.Infrastructure.csproj" />
   </ItemGroup>
 
-  <Target Name="BowerInstall" BeforeTargets="Build">
+  <Target Name="BowerInstall" BeforeTargets="CollectPackageReferences">
     <exec Command="bower install" />
   </Target>
 


### PR DESCRIPTION
because if bower couldn't download packages, bundle can't find them
silly.